### PR TITLE
Use 3.8 for unit tests instead

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Signed-off-by: Gunnar Andersson <gandersson@genivi.org>