### PR TITLE
fix(merge_models): correct ast_as_yaml import typo

### DIFF
--- a/ifex/models/ifex/merge_models.py
+++ b/ifex/models/ifex/merge_models.py
@@ -7,7 +7,7 @@
 
 from dataclasses import fields, is_dataclass, replace
 from ifex.models.ifex.ifex_ast import *
-from ifex.models.common.ast_utils import ast_ast_yaml
+from ifex.models.common.ast_utils import ast_as_yaml
 from ifex.models.ifex.ifex_parser import get_ast_from_yaml_file
 from typing import List, Any, Type
 import copy
@@ -131,11 +131,11 @@ if __name__ == '__main__':
         ast1 = get_ast_from_yaml_file(file1)
         ast2 = get_ast_from_yaml_file(file2)
         merged_ast = merge_asts(ast1, ast2)
-        print(ast_ast_yaml(ast1))
+        print(ast_as_yaml(ast1))
         print ("-----------------------------------------")
-        print(ast_ast_yaml(ast2))
+        print(ast_as_yaml(ast2))
         print ("-----------------------------------------")
-        print(ast_ast_yaml(merged_ast))
+        print(ast_as_yaml(merged_ast))
         print ("=========================================")
     else:
         m1=Method(name="m1", input=[Argument(name="foo", datatype="int32")])
@@ -156,8 +156,8 @@ if __name__ == '__main__':
         merged_ast = merge_asts(ast1, ast2)
         merged_ast.name = "Merged Result"
 
-        print(ast_ast_yaml(ast1))
+        print(ast_as_yaml(ast1))
         print ("-----------------------------------------")
-        print(ast_ast_yaml(ast2))
+        print(ast_as_yaml(ast2))
         print ("=========================================")
-        print(ast_ast_yaml(merged_ast))
+        print(ast_as_yaml(merged_ast))


### PR DESCRIPTION
`merge_models.py` imports `ast_ast_yaml` from `ifex.models.common.ast_utils`, but that name does not exist — the correct export is `ast_as_yaml`. This raises an `ImportError` whenever the module is run as a standalone script. The same typo appears in all call sites within the `__main__` block, so those are fixed too.

Fixes: `ImportError: cannot import name 'ast_ast_yaml' from 'ifex.models.common.ast_utils'`