### PR TITLE
fix(franca_to_ifex): remove undefined log() call and dead code after raise

### DIFF
--- a/ifex/input_filters/franca/franca_to_ifex.py
+++ b/ifex/input_filters/franca/franca_to_ifex.py
@@ -223,7 +223,6 @@ if __name__ == '__main__':
         print(ast_as_yaml(final_ast))
 
     except FileNotFoundError:
-        log("ERROR: File not found")
+        print("ERROR: File not found")
     except Exception as e:
-        raise(e)
-        log("ERROR: An unexpected error occurred: {}".format(e))
+        raise


### PR DESCRIPTION
The `__main__` block has two bugs in its exception handlers:

1. `log("ERROR: File not found")` — `log` is not defined in this module, so a `FileNotFoundError` would immediately be followed by a `NameError`, hiding the real error.  Replaced with `print()`.

2. `raise(e)` followed by `log(...)` — the `log` call is unreachable dead code.  Simplified to a bare `raise` which also preserves the original traceback.