### PR TITLE
fix(merge_overlay): pass node object, not its name string, to merge_nodes

### DIFF
--- a/ifex/transformers/merge_overlay.py
+++ b/ifex/transformers/merge_overlay.py
@@ -100,11 +100,11 @@ def merge_nodes(node1: Any, node2: Any) -> Any:
             if is_removal(value2.name):
                 merged_value = None  # Not storing anything, so it's remmoved
             else:
-                merged_value = merge_nodes(value1, name_only(value2))
+                merged_value = merge_nodes(value1, value2)
         else: # value is a simple field.  Therefore if value2 is defined, it
               # overwrites the original value (there is no "merging" of two fundamental fields)
               # If value2 is not defined, the result defaults back to original value1
-            merged_value = name_only(value2) or value1
+            merged_value = (name_only(value2) if isinstance(value2, str) else value2) or value1
 
         merged_values[var] = merged_value
 


### PR DESCRIPTION
In `merge_nodes`, when recursing into a pair of nested dataclass fields the call was:

```python
merged_value = merge_nodes(value1, name_only(value2))
```

`name_only()` returns a plain `str` (the node name stripped of any `+`/`-` prefix), so the second argument was never a dataclass.  `merge_nodes` immediately short-circuits on `not is_dataclass(node2)` and returns `node2 or node1` — meaning the overlay node was silently discarded every time.  Fix by passing `value2` directly.

The same `else` branch (scalar fields) also called `name_only(value2)` unconditionally, which corrupts non-string scalars such as `int` or `bool`.  Guard it so `name_only` is only invoked when `value2` is a `str`.