### PR TITLE
fix(print_franca_tree): fix recursive call to wrong function name

### DIFF
--- a/ifex/input_filters/franca/print_franca_tree.py
+++ b/ifex/input_filters/franca/print_franca_tree.py
@@ -51,14 +51,14 @@ def franca_ast_to_dict(node, debug_context="") -> OrderedDict:
 
     try:
         _fields = fields(node)
-    except:
+    except Exception:
         print(f"Error occurred processing fields for {node=}")
         _fields = []
 
     for f in _fields:
         item = getattr(node, f.name)
         if not is_empty(item):
-            ret[f.name] = ifex_ast_to_dict(item, debug_context=str(f))
+            ret[f.name] = franca_ast_to_dict(item, debug_context=str(f))
 
     return ret
 


### PR DESCRIPTION
`franca_ast_to_dict` recursed by calling `ifex_ast_to_dict(item, ...)`, a name that does not exist in this module.  Every non-trivial Franca AST node triggers a `NameError` on recursion, making the function entirely non-functional.  Corrected to `franca_ast_to_dict`.

Bare `except:` in the same block is also tightened to `except Exception:` while here.