### PR TITLE
fix(ifex_generator): remove unreachable return; use Exception not BaseException

### DIFF
--- a/ifex/models/ifex/ifex_generator.py
+++ b/ifex/models/ifex/ifex_generator.py
@@ -26,7 +26,7 @@ from ifex.output_filters.templates import JinjaTemplateEnv
 jinja_env = JinjaTemplateEnv.JinjaTemplateEnv("simple")
 
 # Exception:
-class GeneratorError(BaseException):
+class GeneratorError(Exception):
     def __init__(self, m):
         self.msg = m
 
@@ -69,7 +69,6 @@ def _gen_with_default_template(node : Any):
     nodetype=type(node).__name__
     if nodetype == 'StrictUndefined':
         raise GeneratorError(f'The template seems to call gen() with an unknown field name: node {node} is of type StrictUndefined. Please check!')
-        return ""
 
     # Plain types -> print as-is
     if isinstance(node, (str, int, float)):


### PR DESCRIPTION
Two small fixes in `ifex_generator.py`:

1. `return ""` on the line immediately after `raise GeneratorError(...)` is unreachable dead code — removed.
2. `GeneratorError` subclassed `BaseException` directly, which bypasses normal `except Exception` handlers upstream and makes the error unexpectedly hard to catch in calling code.  Changed to subclass `Exception` instead.