### PR TITLE
fix(JinjaSetup): remove unreachable return None; use Exception not BaseException

### DIFF
--- a/ifex/output_filters/JinjaSetup.py
+++ b/ifex/output_filters/JinjaSetup.py
@@ -7,7 +7,7 @@ from ifex.models.ifex import ifex_ast_doc
 from typing import Dict, Any
 
 # Exception:
-class GeneratorError(BaseException):
+class GeneratorError(Exception):
     def __init__(self, m):
         self.msg = m
 
@@ -144,8 +144,6 @@ class JinjaTemplateEnv:
             raise GeneratorError(f'Failure to get actual template object from Jinja framework for {template_file=}')
         else:
             return template.render({"item" : node})
-
-        return None
 
 
     # wrapper over jinja2 to export environment.


### PR DESCRIPTION
Two small fixes in `JinjaSetup.py`:

1. `return None` at the bottom of `render_node` is unreachable: every code path above it either raises or returns a value. Removed.
2. `GeneratorError` subclassed `BaseException` directly, which bypasses normal `except Exception` handlers in calling code. Changed to subclass `Exception`.