### PR TITLE
fix(ifex_to_json_schema): use None sentinels for mutable default args

### DIFF
--- a/ifex/output_filters/schema/ifex_to_json_schema.py
+++ b/ifex/output_filters/schema/ifex_to_json_schema.py
@@ -113,9 +113,13 @@ def print_type(t, fields):
 # Model traversal
 # =======================================================================
 
-def collect_type_info(t, collection={}, seen={}):
+def collect_type_info(t, collection=None, seen=None):
     """This is the main recursive function that loops through tree and collects
        information about its structure which is later used to output the schema:"""
+    if collection is None:
+        collection = {}
+    if seen is None:
+        seen = {}
 
     # We don't need to gather information about primitive types because they
     # will not have any member fields below them.


### PR DESCRIPTION
`collect_type_info(t, collection={}, seen={})` uses mutable dicts as default arguments.  Python creates these once at function-definition time and reuses the same objects on every call that omits those arguments.

After the first call:
- `seen` retains all visited type names, so any subsequent call skips every node and collects nothing.
- `collection` accumulates entries from previous calls, polluting results.

Fix with the standard `None`-sentinel pattern.