### PR TITLE
fix(rule_translator): replace bare except with except AttributeError

### DIFF
--- a/ifex/transformers/rule_translator.py
+++ b/ifex/transformers/rule_translator.py
@@ -240,7 +240,7 @@ def transform_value_common(mapping_table, value, field_transform):
             name = ""
             try:
                 name = value.name
-            except:
+            except AttributeError:
                 pass
             _log("DEBUG", f"Empty OrderedDict for {value=} {name=} {field_transform=}")
             value = []


### PR DESCRIPTION
The bare `except:` clause in `transform_value_common` catches everything — including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` — which can make the program unresponsive to Ctrl-C or swallow crash signals.  The intent is clearly to handle the case where the `OrderedDict` value has no `.name` attribute.  Narrow to `except AttributeError`.