### PR TITLE
fix(type_checking_constructor_mixin): narrow bare except to AttributeError

### DIFF
--- a/ifex/models/common/type_checking_constructor_mixin.py
+++ b/ifex/models/common/type_checking_constructor_mixin.py
@@ -100,7 +100,7 @@ def add_constructor(cls):
             if not is_correct_type(value, arg_types[name]):
                 try:
                     nameinfo = f"Additional Info:  The object was named: {self.name}"
-                except:
+                except AttributeError:
                     nameinfo = ""
                 raise TypeError(f'Object construction error for class {type(self)}: According to specification, value named \'{name}\' must be of type: {arg_types[name]}, but was instead: {type(value)!r}. {nameinfo}')
 


### PR DESCRIPTION
The bare `except:` in `type_checking_constructor` catches every exception, including `KeyboardInterrupt` and `SystemExit`.  The block exists solely to handle the case where `self` has no `.name` attribute, so narrow it to `except AttributeError`.