### PR TITLE
fix(generic_testrunner): remove dead code after return statement

### DIFF
--- a/tests/generic_testrunner.py
+++ b/tests/generic_testrunner.py
@@ -157,11 +157,6 @@ def run_tests(test_root_dir):
 
         return exit_code, output, input_file
 
-
-        # Fail if we are unable?
-        #return -1, "NOTRUN", "NOFILE"
-        raise Exception()
-
     # Symlink -> points to the program to run
     if is_link('program'):
         program = get_program_link()


### PR DESCRIPTION
A commented-out `return` line and an unconditional `raise Exception()` were placed after a `return exit_code, output, input_file` statement, making the entire block unreachable.  Remove the dead block.