### PR TITLE
fix(diff_ifex): clean up temp files; fix stable_order_file return path

### DIFF
--- a/helpers/ifex/diff_ifex.py
+++ b/helpers/ifex/diff_ifex.py
@@ -43,12 +43,11 @@ def stable_order_file(file1):
     """Writes a new file containing the YAML content with keys in order, and
     returns the file name"""
     with open(file1, "r") as f1:
-        with tempfile.NamedTemporaryFile("w", delete=False) as f2:
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as f2:
+            tmpname = f2.name
             yaml.add_representer(OrderedDict, represent_ordereddict)
             f2.write(yaml.dump(ifex_stable_order(yaml.safe_load(f1)), sort_keys=False))
-            return f2.name
-
-    return None  # Will fail on exception before this
+    return tmpname
 
 
 def compare_yaml_files(file1, file2):
@@ -56,11 +55,18 @@ def compare_yaml_files(file1, file2):
     files, then diff the results"""
     f1 = stable_order_file(file1)
     f2 = stable_order_file(file2)
-
-    print("Stable sorting...")
-    print(f"temporary files are {file1} -> {f1}, {file2} -> {f2}")
-    print("Comparing files:")
-    return diff_files_with_external_program(f1, f2)
+    try:
+        print("Stable sorting...")
+        print(f"temporary files are {file1} -> {f1}, {file2} -> {f2}")
+        print("Comparing files:")
+        return diff_files_with_external_program(f1, f2)
+    finally:
+        import os as _os
+        for tmp in [f1, f2]:
+            try:
+                _os.unlink(tmp)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Two fixes in `helpers/ifex/diff_ifex.py`:

1. `stable_order_file` returned from inside the `with NamedTemporaryFile` block, causing the file to be closed by the context manager while still referenced by the return value — but more importantly the fallthrough `return None` was dead code. Refactor: capture the name before exiting the with-block, then return after.

2. `compare_yaml_files` created two temp files but never deleted them, leaking one or two files per invocation. Wrap the diff call in `try/finally` and unlink both files on exit (ignoring `OSError` in case a file was already removed).