### PR TITLE
fix(generator, generator_dbus): remove undefined filename variable from error message

### DIFF
--- a/distribution/entrypoints/generator.py
+++ b/distribution/entrypoints/generator.py
@@ -17,7 +17,7 @@ def ifex_generator_run():
     try:
         args = parser.parse_args()
     except dacite.UnexpectedDataError as e:
-        print(f"ERROR: Read error resulting from {filename}: {e}")
+        print(f"ERROR: Read error: {e}")
 
     ast = get_ast_from_yaml_file(args.input)
 

--- a/distribution/entrypoints/generator_dbus.py
+++ b/distribution/entrypoints/generator_dbus.py
@@ -17,7 +17,7 @@ def ifex_dbus_generator_run():
         dbus_generator.main_generate(args.input)
 
     except dacite.UnexpectedDataError as e:
-        print(f"ERROR: Read error resulting from {filename}: {e}")
+        print(f"ERROR: Read error: {e}")
 
 if __name__ == "__main__":
     ifex_dbus_generator_run()


### PR DESCRIPTION
Both `generator.py` and `generator_dbus.py` referenced `filename` in the except-clause error message:

```python
print(f"ERROR: Read error resulting from {filename}: {e}")
```

`filename` is never defined in either function's scope — the parsed argument is `args.input`, and `args` is only assigned inside the `try` block.  If the exception were actually raised, it would be immediately followed by a `NameError`, hiding the original error.  Simplify the message to remove the undefined variable.