### PR TITLE
fix(JinjaSetup, TemplateDir): bind root from os.walk to fix NameError in recursive search

### DIFF
--- a/ifex/output_filters/JinjaSetup.py
+++ b/ifex/output_filters/JinjaSetup.py
@@ -45,7 +45,7 @@ class TemplateFinder:
 
         templates = {}  # Dict maps node name to the template file name
         if recurse:
-            for _,_,filenames in os.walk(directory):
+            for root, _, filenames in os.walk(directory):
                 for ff in filenames:
                     for n in classes:
                         if ff.startswith(n + '.'):

--- a/ifex/output_filters/templates/TemplateDir.py
+++ b/ifex/output_filters/templates/TemplateDir.py
@@ -18,7 +18,7 @@ def find_matching_template_files(directory : str, recurse = False, absolute = Fa
 
     templates = {}  # Dict maps node name to the template file name
     if recurse:
-        for _, _, filenames in os.walk(directory):
+        for root, _, filenames in os.walk(directory):
             for fn in filenames:
                 for n in classes:
                     if fn.startswith(n):


### PR DESCRIPTION
Both `find_matching_template_files` implementations unpacked `os.walk` as `for _, _, filenames`, discarding the `root` directory string.  The body then built file paths using `os.path.join(root, ff)`, referencing an undefined variable.  Calling either function with `recurse=True` raises a `NameError`.

Fix by binding the first value to `root` instead of discarding it with `_`.