### PR TITLE
fix(franca_to_ifex): remove duplicate franca.Int16 entry in type_translation

### DIFF
--- a/ifex/input_filters/franca/franca_to_ifex.py
+++ b/ifex/input_filters/franca/franca_to_ifex.py
@@ -140,7 +140,6 @@ type_translation = {
     franca.Float : "float",
     franca.Int8 : "int8",
     franca.Int16 : "int16",
-    franca.Int16 : "int16",
     franca.Int32 : "int32",
     franca.Int64 : "int64",
     franca.String : "string",


### PR DESCRIPTION
`type_translation` contained the entry `franca.Int16 : "int16"` twice.  Python silently uses the last definition for any duplicate dict key.  Here both values are the same so the mapping is still correct, but the duplicate is misleading and would mask a copy-paste error if the second entry were ever changed to a different target type.  Remove the duplicate line.