### PR TITLE
fix(protobuf_lark): replace undefined TypeException with TypeError

### DIFF
--- a/ifex/models/protobuf/protobuf_lark.py
+++ b/ifex/models/protobuf/protobuf_lark.py
@@ -112,7 +112,7 @@ def matcher(node, pattern):
                 match_str(node.value, pattern.value) )
     # => ?
     else:
-        raise TypeException("Unknown type passed to matcher() - please check!")
+        raise TypeError("Unknown type passed to matcher() - please check!")
 
 
 # Helper to extract a subtree of a certain type (as identified by the grammar rule name)


### PR DESCRIPTION
`TypeException` is not defined anywhere in the codebase.  The `else` branch of `matcher()` would raise a `NameError` instead of the intended error when an unexpected node type is passed.  Replace with the standard `TypeError`.