### PR TITLE
fix(protobuf_lark): add missing raise for multiple-package error

### DIFF
--- a/ifex/models/protobuf/protobuf_lark.py
+++ b/ifex/models/protobuf/protobuf_lark.py
@@ -648,7 +648,7 @@ def process_lark_tree(root):
     packages = get_items_of_type(root, 'package')
 
     if len(packages) > 1:
-        Exception("Multiple package statements found!  The protobuf spec is ambiguous on multiple package statements (EBNF grammar allows multiple but the explanation suggests a singular use).  This implementation chose to support only one per file.  (If multiple are needed, please contact the IFEX project)")
+        raise Exception("Multiple package statements found!  The protobuf spec is ambiguous on multiple package statements (EBNF grammar allows multiple but the explanation suggests a singular use).  This implementation chose to support only one per file.  (If multiple are needed, please contact the IFEX project)")
     ast_package = None
     if len(packages) > 0:
         ast_package = process_package(packages[0])


### PR DESCRIPTION
In `process_lark_tree`, the check for multiple `package` statements called `Exception(...)` without `raise`.  The exception object was constructed and immediately garbage-collected, so protobuf files with more than one `package` statement silently continued processing instead of failing with an error.  Add `raise`.