### PR TITLE
fix(protobuf_lark): replace bare assert with explicit raise ValueError

### DIFF
--- a/ifex/models/protobuf/protobuf_lark.py
+++ b/ifex/models/protobuf/protobuf_lark.py
@@ -623,7 +623,8 @@ def process_enums(e):
     for o in options:
         # Node of option type -> process the embedded optiondef
         # Should be one child of type optiondef here
-        assert(len(o.children) == 1)
+        if len(o.children) != 1:
+            raise ValueError(f"Expected exactly one child in option node, got {len(o.children)}")
         optiondef_node = o.children.pop(0)
         assert_rule_match(optiondef_node, 'optiondef')
         ast_options.append(process_option(optiondef_node))
@@ -683,7 +684,8 @@ def process_lark_tree(root):
     for o in options:
         # Node of option type -> process the embedded optiondef
         # Should be one child of type optiondef here
-        assert(len(o.children) == 1)
+        if len(o.children) != 1:
+            raise ValueError(f"Expected exactly one child in option node, got {len(o.children)}")
         optiondef_node = o.children.pop(0)
         assert_rule_match(optiondef_node, 'optiondef')
         ast_options.append(process_option(optiondef_node))


### PR DESCRIPTION
Two `assert(len(o.children) == 1)` calls in `process_enums` and `process_lark_tree` validate the shape of a parsed option node.  Bare `assert` statements are silently disabled when Python is run with the `-O` flag (optimised mode, e.g. in some production deployments), meaning malformed nodes would pass through silently.

Replace each with an explicit `if … raise ValueError(...)` so the check is always active and produces a diagnostic message that includes the actual count.