### PR TITLE
fix(ast_utils): use field.type and field.name in prune function

### DIFF
--- a/ifex/models/common/ast_utils.py
+++ b/ifex/models/common/ast_utils.py
@@ -349,8 +349,8 @@ def prune(node: Any, field_values: Dict[str, Any], recursive=True, force=False):
 
             # Prune single item if matching
             elif all_fields_match(node, field_values):
-                if is_optional(field) or force:
-                    setattr(node, field, None)
+                if is_optional(field.type) or force:
+                    setattr(node, field.name, None)
                 else:
                     raise Exception("Prune tried to delete node which is mandatory. Use force=true to override")
 


### PR DESCRIPTION
Two bugs in the `prune` function body:

1. `is_optional(field)` — `field` is a `dataclasses.Field` object, but `is_optional` expects a *type indicator* (e.g. `Optional[str]`). Pass `field.type` instead.
2. `setattr(node, field, None)` — `field` is again the `Field` object, not a string attribute name. Pass `field.name` instead.

Both would raise a `TypeError` or `AttributeError` at runtime whenever `prune` was called on a node that matched the given field values.