### PR TITLE
fix(ifex_generator): call jinja_env.get_template not undefined get_template

### DIFF
--- a/ifex/models/ifex/ifex_generator.py
+++ b/ifex/models/ifex/ifex_generator.py
@@ -100,7 +100,7 @@ def gen_template_text(node: Any, template_text: str):
 
 # Entry point for passing a dictionary of variables instead:
 def gen_dict_with_template_file(variables : dict, templatefile):
-    return get_template(templatefile).render(variables)
+    return jinja_env.get_template(templatefile).render(variables)
 
 # Export the gen() function and classes into jinja template land
 # so that they can be referred to inside templates.


### PR DESCRIPTION
`gen_dict_with_template_file` called `get_template(templatefile)`, but `get_template` is not defined at module scope.  The Jinja environment is stored in the module-level `jinja_env` object.  Calling this function raised a `NameError`.  Fix: `jinja_env.get_template(templatefile)`.