### PR TITLE
fix(rule_translator): correct guard logic for None / all-None-list values

### DIFF
--- a/ifex/transformers/rule_translator.py
+++ b/ifex/transformers/rule_translator.py
@@ -388,7 +388,7 @@ def transform(mapping_table, input_obj):
             value = transform_value_common(mapping_table, getattr_value(input_obj, input_attr), field_transform)
 
             # Set attribute unless the result was None (or sometimes due to list handling, a *list* of None values)
-            if value != None and (isinstance(value, list) and not all([x == None for x in value])):
+            if value is not None and (not isinstance(value, list) or not all(x is None for x in value)):
                 set_attr(attributes, output_attr, value)
 
             # Mark this attribute as handled


### PR DESCRIPTION
In `transform`, after calling `transform_value_common`, the result is only stored if it is not empty:

```python
if value != None and (isinstance(value, list) and not all([x == None for x in value])):
```

The bug: the second operand of `and` requires `value` to be a list.  If `value` is any non-None scalar (a `str`, `int`, or an AST node), `isinstance(value, list)` is `False`, so the whole right-hand side is `False`, and the attribute is silently discarded.  This causes every non-list field in every translated object to be dropped.

The intended guard is: _skip_ if `value is None`, or if `value` is a list where every element is `None`.  The correct expression:

```python
if value is not None and (not isinstance(value, list) or not all(x is None for x in value)):
```