### PR TITLE
refactor: replace if/type chains with match/case

### DIFF
--- a/ifex/input_filters/franca/franca_to_ifex.py
+++ b/ifex/input_filters/franca/franca_to_ifex.py
@@ -157,32 +157,29 @@ type_translation = {
 # ----------------------------------------------------------------------------
 
 def translate_type(t):
-
-    # Special case: For references to complex types we want to refer to the original type name, since IFEX supports
-    # named type definitions as well.  The type ought to be translated into a named typedef (or enum or struct, etc.) in
-    # the IFEX representation also.  We don't need to de-reference it once more and end up with the inner definition of
-    # the typedef, since IFEX supports named type definitions as well -> so don't recurse to figure out the inner type.
-    if type(t) is franca.Reference and type(t.reference) in [franca.Array, franca.Struct, franca.Enumeration,
-                                                             franca.Typedef, franca.Map]:
-        return t.reference.name
-
-    # Other references in a Franca AST are just some level of indirection -> Recurse on the actual type.
-    # TODO: Check if this case still happens, considering previous lines?
-    if type(t) is franca.Reference:
-        return translate_type(t.reference)
-
-    # This case can happen for arrays for plain-types that are defined directly, without a named typedef.
-    # -> Translate the array's inner simple type, and add array to it.
-    if type(t) is franca.Array:
-        return translate_type(t.type) + '[]'
-
-    # TODO This case is now probably redundant but let's come back to the comment about how to use qualified names
-    if type(t) is franca.Enumeration:
-        return t.name # FIXME use qualified name <InterfaceName>_<EnumerationName>, or change in the other place
-
-    # Plain type -> use lookup table and if that fails return the original for now
-    t2 = type_translation.get(type(t))
-    return t2 if t2 is not None else t
+    match t:
+        # Special case: For references to complex types we want to refer to the original type name, since IFEX supports
+        # named type definitions as well.  The type ought to be translated into a named typedef (or enum or struct, etc.)
+        # in the IFEX representation also.  We don't need to de-reference it once more and end up with the inner
+        # definition of the typedef, since IFEX supports named type definitions as well -> so don't recurse.
+        case franca.Reference() if type(t.reference) in [franca.Array, franca.Struct, franca.Enumeration,
+                                                          franca.Typedef, franca.Map]:
+            return t.reference.name
+        # Other references in a Franca AST are just some level of indirection -> Recurse on the actual type.
+        # TODO: Check if this case still happens, considering previous lines?
+        case franca.Reference():
+            return translate_type(t.reference)
+        # This case can happen for arrays for plain-types that are defined directly, without a named typedef.
+        # -> Translate the array's inner simple type, and add array to it.
+        case franca.Array():
+            return translate_type(t.type) + '[]'
+        # TODO This case is now probably redundant but let's come back to the comment about qualified names
+        case franca.Enumeration():
+            return t.name  # FIXME use qualified name <InterfaceName>_<EnumerationName>, or change in the other place
+        # Plain type -> use lookup table and if that fails return the original for now
+        case _:
+            t2 = type_translation.get(type(t))
+            return t2 if t2 is not None else t
 
 
 # Rename fidl to ifex, for imports

--- a/ifex/models/DBus/dbus_types.py
+++ b/ifex/models/DBus/dbus_types.py
@@ -85,38 +85,25 @@ def get_array_member(typename):
 # Main IFEX to D-Bus type translator:  This function will recurse until a D-Bus
 # supported primitive type has been created.
 def gen_dbus_type(ifextype):
-    dbus_type = ""
-    # Iterate over lists
-    if isinstance(ifextype, list):
-        for t in ifextype:
-            dbus_type += f"{t} => {gen_dbus_type(t)}\n"
-    # Array of items
-    elif is_array(ifextype):
-        dbus_type += "a" + gen_dbus_type(get_array_member(ifextype))
-    # Typedef/Enumeration -> just translate to the underlying type
-    elif isinstance(ifextype, Typedef) or isinstance(ifextype, Enumeration):
-        dbus_type += gen_dbus_type(ifextype.datatype)
-    # Struct of items -> parentheses, and recurse on struct members
-    elif isinstance(ifextype, Struct):
-        dbus_type += "("
-        for m in ifextype.members:
-            dbus_type += gen_dbus_type(m)
-        dbus_type += ")"
-    # Member (of Struct) -> translate its datatype
-    elif isinstance(ifextype, Member):
-        dbus_type += gen_dbus_type(ifextype.datatype)
-    # Direct type name, (non-array)
-    else:
-        dbt = ifex_to_dbus_types.get(ifextype)
-        known_type = known_ifex_type_definitions.get(ifextype)
-        if dbt is not None:
-            dbus_type += dbt
-        elif known_type is not None:
-            dbus_type += gen_dbus_type(known_type)
-        else:
-            dbus_type += f"UNKNOWN_TYPE({ifextype})"
-
-    return dbus_type
+    match ifextype:
+        case list():
+            return "".join(f"{t} => {gen_dbus_type(t)}\n" for t in ifextype)
+        case str() if is_array(ifextype):
+            return "a" + gen_dbus_type(get_array_member(ifextype))
+        case Typedef() | Enumeration():
+            return gen_dbus_type(ifextype.datatype)
+        case Struct():
+            return "(" + "".join(gen_dbus_type(m) for m in ifextype.members) + ")"
+        case Member():
+            return gen_dbus_type(ifextype.datatype)
+        case str():
+            dbt = ifex_to_dbus_types.get(ifextype)
+            known_type = known_ifex_type_definitions.get(ifextype)
+            if dbt is not None:
+                return dbt
+            if known_type is not None:
+                return gen_dbus_type(known_type)
+            return f"UNKNOWN_TYPE({ifextype})"
 
 
 # Registry for type definitions taken from the IFEX file
@@ -137,31 +124,31 @@ known_ifex_type_definitions = {}
 # => no multithreading/parallel use.
 # (if later needed the module shall be converted into an instantiable class instead)
 # The node parameter is a dataclass instance, as returned from the dacite conversion
+def _collect_type_definitions(node):
+    """Register struct/typedef/enum definitions from a Namespace or Interface."""
+    for x in node.structs:
+        known_ifex_type_definitions[x.name] = x
+    for x in node.typedefs:
+        known_ifex_type_definitions[x.name] = x.datatype
+    for x in node.enumerations:
+        known_ifex_type_definitions[x.name] = x.datatype
+
+
 def collect_types(node):
     # FIXME: Shall this also handle partial type-defining files that lack namespace structure?
-
-    # Recurse over each instance in a list
-    if type(node) is list:
-        for listitem in node:
-            collect_types(listitem)
-        return
-
-    # Recurse on each (sub)-namespace
-    if type(node) in [Namespace, AST]:
-        collect_types(node.namespaces)
-
-    # Types can be collected from either a Namespace or an Interface
-    if type(node) in [Interface, Namespace]:
-        for x in node.structs:
-            known_ifex_type_definitions[x.name] = x
-        for x in node.typedefs:
-            known_ifex_type_definitions[x.name] = x.datatype
-        for x in node.enumerations:
-            known_ifex_type_definitions[x.name] = x.datatype
-
-    # Finally, a single Interface can be underneath any Namespace
-    if type(node) is Namespace and node.interface is not None:
-        collect_types(node.interface)
+    match node:
+        case list():
+            for listitem in node:
+                collect_types(listitem)
+        case AST():
+            collect_types(node.namespaces)
+        case Namespace():
+            collect_types(node.namespaces)
+            _collect_type_definitions(node)
+            if node.interface is not None:
+                collect_types(node.interface)
+        case Interface():
+            _collect_type_definitions(node)
 
 
 # main() = FOR MODULE TEST ONLY - NOT USED BY MAIN CODE GENERATOR


### PR DESCRIPTION
Closes #140

## Changes

Converts `isinstance`/`type()` if-chains to `match`/`case` in the two files called out in the issue:

### `ifex/models/DBus/dbus_types.py`

**`gen_dbus_type()`** — six branches replaced by five match arms.  `Typedef | Enumeration` written as a single OR pattern.  Accumulating into a mutable `dbus_type` string replaced by early returns.

**`collect_types()`** — four separate `if type(node) in [...]` checks (which could fall through into each other) replaced by a clean `match` with per-type cases.  Shared struct/typedef/enum registration logic extracted into `_collect_type_definitions()` to avoid duplication between the `Namespace` and `Interface` arms.

### `ifex/input_filters/franca/franca_to_ifex.py`

**`translate_type()`** — four sequential `if type(t) is` guards replaced by `match` arms.  The guarded first Reference case (`type(t.reference) in [...]`) is preserved as a match guard.  All comments kept in place.

## Notes

- No behaviour changes; pure structural refactor.
- Requires Python ≥ 3.10 (already required by the repo).